### PR TITLE
amended API_ROOT to disable https on the back-end

### DIFF
--- a/src/agent.js
+++ b/src/agent.js
@@ -3,7 +3,8 @@ import _superagent from 'superagent';
 
 const superagent = superagentPromise(_superagent, global.Promise);
 
-const API_ROOT = 'https://conduit.productionready.io/api';
+//POINTING API_ROOT AT HTTPS:// SERVICE WITHOUT HAVING HTTPS:// INITIALIZED ON OUR END CAUSES USE HEADACHES INVOLVED 
+const API_ROOT = 'http://conduit.productionready.io/api';
 
 const encode = encodeURIComponent;
 const responseBody = res => res.body;


### PR DESCRIPTION
Until such a time as the local environment is configured to support https connections, back-end traffic needs to be sent over http connection due to strict CORS policy in Google Chrome